### PR TITLE
Handle error when pynvml exists but underlying NVML library not.

### DIFF
--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -53,6 +53,8 @@ if MONITOR_DCGM is False:
         print('Monitoring GPUs with pynvml')
     except ImportError:
         MONITOR_PYNVML = False
+    except pynvml.NVMLError_LibraryNotFound:
+        MONITOR_PYNVML = False
     except pynvml.NVMLError_DriverNotLoaded:
         MONITOR_PYNVML = False
 


### PR DESCRIPTION
When running the exporter in a virtual env that contains pynvml on a host that does not have NVIDIA libraries installed we get an error "Library not found":  `pynvml.NVMLError_LibraryNotFound`

This patch adds a clause to handle this error.