### PR TITLE
DCGM is gauges and not counters for bandwidth measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ slurm_job_fp32_gpu{account="group2",gpu="0",gpu_type="NVIDIA A100-SXM4-40GB",slu
 # TYPE slurm_job_fp16_gpu gauge
 slurm_job_fp16_gpu{account="group1",gpu="1",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="1",user="user1"} 0.0
 slurm_job_fp16_gpu{account="group2",gpu="0",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="2",user="user2"} 0.0
-# HELP slurm_job_pcie_gpu_total PCIe tx/rx bytes
-# TYPE slurm_job_pcie_gpu_total counter
+# HELP slurm_job_pcie_gpu_total PCIe tx/rx bytes per second
+# TYPE slurm_job_pcie_gpu_total gauge
 slurm_job_pcie_gpu_total{account="group1",direction="TX",gpu="1",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="1",user="user1"} 9.6079424e+07
 slurm_job_pcie_gpu_total{account="group1",direction="RX",gpu="1",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="1",user="user1"} 8.1315216e+08
 slurm_job_pcie_gpu_total{account="group2",direction="TX",gpu="0",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="2",user="user2"} 1.0392774e+07
 slurm_job_pcie_gpu_total{account="group2",direction="RX",gpu="0",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="2",user="user2"} 4.4930668e+07
-# HELP slurm_job_nvlink_gpu_total Nvlink tx/rx bytes
-# TYPE slurm_job_nvlink_gpu_total counter
+# HELP slurm_job_nvlink_gpu_total Nvlink tx/rx bytes per second
+# TYPE slurm_job_nvlink_gpu_total gauge
 slurm_job_nvlink_gpu_total{account="group1",direction="TX",gpu="1",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="1",user="user1"} 0.0
 slurm_job_nvlink_gpu_total{account="group1",direction="RX",gpu="1",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="1",user="user1"} 0.0
 slurm_job_nvlink_gpu_total{account="group2",direction="TX",gpu="0",gpu_type="NVIDIA A100-SXM4-40GB",slurmjobid="2",user="user2"} 0.0

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -225,11 +225,11 @@ per elapsed cycle)',
                 'slurm_job_fp16_gpu',
                 'Ratio of cycles the fp16 pipe is active',
                 labels=['user', 'account', 'slurmjobid', 'gpu', 'gpu_type'])
-            counter_nvlink_gpu = CounterMetricFamily(
-                'slurm_job_nvlink_gpu', 'Nvlink tx/rx bytes',
+            gauge_nvlink_gpu = GaugeMetricFamily(
+                'slurm_job_nvlink_gpu', 'Nvlink tx/rx bytes per second',
                 labels=['user', 'account', 'slurmjobid', 'gpu', 'gpu_type', 'direction'])
-            counter_pcie_gpu = CounterMetricFamily(
-                'slurm_job_pcie_gpu', 'PCIe tx/rx bytes',
+            gauge_pcie_gpu = GaugeMetricFamily(
+                'slurm_job_pcie_gpu', 'PCIe tx/rx bytes per second',
                 labels=['user', 'account', 'slurmjobid', 'gpu', 'gpu_type', 'direction'])
 
         for uid_dir in glob.glob("/sys/fs/cgroup/memory/slurm/uid_*"):
@@ -398,16 +398,16 @@ cpuacct.usage_percpu'.format(uid, job), 'r') as f_usage:
                             [user, account, job, str(gpu), gpu_type],
                             dcgm_data[gpu]['fp16_active'] * 100)
 
-                        counter_pcie_gpu.add_metric(
+                        gauge_pcie_gpu.add_metric(
                             [user, account, job, str(gpu), gpu_type, 'TX'],
                             dcgm_data[gpu]['pcie_tx_bytes'])
-                        counter_pcie_gpu.add_metric(
+                        gauge_pcie_gpu.add_metric(
                             [user, account, job, str(gpu), gpu_type, 'RX'],
                             dcgm_data[gpu]['pcie_rx_bytes'])
-                        counter_nvlink_gpu.add_metric(
+                        gauge_nvlink_gpu.add_metric(
                             [user, account, job, str(gpu), gpu_type, 'TX'],
                             dcgm_data[gpu]['nvlink_tx_bytes'])
-                        counter_nvlink_gpu.add_metric(
+                        gauge_nvlink_gpu.add_metric(
                             [user, account, job, str(gpu), gpu_type, 'RX'],
                             dcgm_data[gpu]['nvlink_rx_bytes'])
 
@@ -436,8 +436,8 @@ cpuacct.usage_percpu'.format(uid, job), 'r') as f_usage:
             yield gauge_fp64_gpu
             yield gauge_fp32_gpu
             yield gauge_fp16_gpu
-            yield counter_pcie_gpu
-            yield counter_nvlink_gpu
+            yield gauge_pcie_gpu
+            yield gauge_nvlink_gpu
 
 
 class NoLoggingWSGIRequestHandler(WSGIRequestHandler):


### PR DESCRIPTION
DCGM is using gauges and not counters for PCIe/NVLink bandwidth

The official documentation and headers are wrong
https://github.com/NVIDIA/dcgm-exporter/issues/87#issuecomment-1198946346
https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html#c.DCGM_FI_PROF_PCIE_TX_BYTES