### PR TITLE
Support cgroup v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ optional arguments:
   --port PORT  Collector http port, default is 9798
 ``` 
 
+## Cgroup v1 vs v2
+[Slurm currently supports cgroup v1 and v2](https://slurm.schedmd.com/cgroup_v2.html), but there are some limitations with v2, some metrics are not currently available on this exporter:
+
+* `memory.max_usage_in_bytes` becomes `memory.peak`, but this is not in any currently released kernel ([torvalds/linux@8e20d4b](https://github.com/torvalds/linux/commit/8e20d4b332660a32e842e20c34cfc3b3456bc6dc))
+* `cpuacct.usage_percpu` is exposed via eBPF in kernel 6.6+, but not through cgroupfs although it might be for a future kernel.
+
 ## Sample
 ```
 # HELP slurm_job_memory_usage Memory used by a job

--- a/get_gpus.sh
+++ b/get_gpus.sh
@@ -2,7 +2,6 @@
 # instead of cgexec that is deprecated in rhel9, we simply bind this bash
 # process to the cgroup, then nvidia-smi will be able to see the GPU
 # of the cgroup of the running job
-uid=$1
-job=$2
-echo $$ >> /sys/fs/cgroup/devices/slurm/uid_${uid}/job_${job}/tasks
+task_file=$1
+echo $$ >> "$task_file"
 nvidia-smi -L

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -30,8 +30,8 @@ def cgroup_processes(job_dir):
     procs = []
     res_uid = -1
     for (path, _, _)  in os.walk(job_dir):
-        with open(os.path.join(path, "cgroup.procs"), 'r') as procs:
-            for proc in procs.readlines():
+        with open(os.path.join(path, "cgroup.procs"), 'r') as fprocs:
+            for proc in fprocs.readlines():
                 pid = int(proc)
                 try:
                     ps = psutil.Process(pid)

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -351,19 +351,19 @@ per elapsed cycle)',
                 # Could not find the env variables, slurm_adopt only fill the jobid
                 account = "error"
 
-            with open(job_dir + ('memory.usage_in_bytes' if cgroups == 1 else 'memory.current'), 'r') as f_usage:
+            with open(os.path.join(job_dir, ('memory.usage_in_bytes' if cgroups == 1 else 'memory.current')), 'r') as f_usage:
                 gauge_memory_usage.add_metric([user, account, job], int(f_usage.read()))
             try:
-                with open(job_dir + ('memory.max_usage_in_bytes' if cgroups == 1 else 'memory.peak'), 'r') as f_max:
+                with open(os.path.join(job_dir, ('memory.max_usage_in_bytes' if cgroups == 1 else 'memory.peak')), 'r') as f_max:
                     gauge_memory_max.add_metric([user, account, job], int(f_max.read()))
             except FileNotFoundError:
                 # 'memory.peak' is only available in kernel 6.8+
                 pass
 
-            with open(job_dir + ('memory.limit_in_bytes' if cgroups == 1 else 'memory.max'), 'r') as f_limit:
+            with open(os.path.join(job_dir, ('memory.limit_in_bytes' if cgroups == 1 else 'memory.max')), 'r') as f_limit:
                 gauge_memory_limit.add_metric([user, account, job], int(f_limit.read()))
 
-            with open(job_dir + 'memory.stat', 'r') as f_stats:
+            with open(os.path.join(job_dir, 'memory.stat'), 'r') as f_stats:
                 stats = dict(line.split() for line in f_stats.readlines())
             if cgroups == 1:
                 gauge_memory_cache.add_metric(

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -300,134 +300,166 @@ per elapsed cycle)',
                 'slurm_job_pcie_gpu', 'PCIe tx/rx bytes per second',
                 labels=['user', 'account', 'slurmjobid', 'gpu', 'gpu_type', 'direction'])
 
-        for uid_dir in glob.glob("/sys/fs/cgroup/memory/slurm/uid_*"):
-            uid = uid_dir.split('/')[-1].split('_')[1]
-            job_path = "/sys/fs/cgroup/memory/slurm/uid_{}/job_*".format(uid)
-            for job_dir in glob.glob(job_path):
-                job = job_dir.split('/')[-1].split('_')[1]
-                mem_path = '/sys/fs/cgroup/memory/slurm/uid_{}/job_{}/'.format(
-                    uid, job)
-                uid, procs = cgroup_processes(job_dir)
-                if len(procs) == 0:
+        if os.path.exists("/sys/fs/cgroup/memory"):
+            cgroups = 1  # we are running cgroups v1
+        else:
+            cgroups = 2  # we are running cgroups v2
+
+        if cgroups == 1:
+            jobs_glob = "/sys/fs/cgroup/memory/slurm/uid_*/job_*"
+        else:
+            jobs_glob = "/sys/fs/cgroup/system.slice/slurmstepd.scope/job_*"
+        for job_dir in glob.glob(jobs_glob):
+            job = job_dir.split('/')[-1].split('_')[1]
+            uid, procs = cgroup_processes(job_dir)
+            if len(procs) == 0:
+                continue
+
+            # Job is alive, we can get the stats
+            user = get_username(uid)
+            gpu_set = set()
+            if self.MONITOR_PYNVML or self.MONITOR_DCGM:
+                gpu_set.update(cgroup_gpus(uid, job))
+
+            for proc in procs:
+                # get the SLURM_JOB_ACCOUNT
+                try:
+                    envs = get_env(proc)
+                except ValueError:
+                    # Process does not have an environment, its probably gone
                     continue
+                if 'SLURM_JOB_ACCOUNT' in envs:
+                    account = envs['SLURM_JOB_ACCOUNT']
+                    break
+            else:
+                # Could not find the env variables, slurm_adopt only fill the jobid
+                account = "error"
 
-                # Job is alive, we can get the stats
-                user = get_username(uid)
-                gpu_set = set()
-                if self.MONITOR_PYNVML or self.MONITOR_DCGM:
-                    gpu_set.update(cgroup_gpus(uid, job))
-
-                for proc in procs:
-                    # get the SLURM_JOB_ACCOUNT
-                    try:
-                        envs = get_env(proc)
-                    except ValueError:
-                        # Process does not have an environment, its probably gone
-                        continue
-                    if 'SLURM_JOB_ACCOUNT' in envs:
-                        account = envs['SLURM_JOB_ACCOUNT']
-                        break
-                else:
-                    # Could not find the env variables, slurm_adopt only fill the jobid
-                    account = "error"
-
-                with open(mem_path + 'memory.usage_in_bytes', 'r') as f_usage:
-                    gauge_memory_usage.add_metric([user, account, job], int(f_usage.read()))
-                with open(mem_path + 'memory.max_usage_in_bytes', 'r') as f_max:
+            with open(job_dir + ('memory.usage_in_bytes' if cgroups == 1 else 'memory.current'), 'r') as f_usage:
+                gauge_memory_usage.add_metric([user, account, job], int(f_usage.read()))
+            try:
+                with open(job_dir + ('memory.max_usage_in_bytes' if cgroups == 1 else 'memory.peak'), 'r') as f_max:
                     gauge_memory_max.add_metric([user, account, job], int(f_max.read()))
-                with open(mem_path + 'memory.limit_in_bytes', 'r') as f_limit:
-                    gauge_memory_limit.add_metric([user, account, job], int(f_limit.read()))
+            except FileNotFoundError:
+                # 'memory.peak' is only available in kernel 6.8+
+                pass
 
-                with open(mem_path + 'memory.stat', 'r') as f_stats:
-                    for line in f_stats.readlines():
-                        data = line.split()
-                        if data[0] == 'total_cache':
-                            gauge_memory_cache.add_metric([user, account, job], int(data[1]))
-                        elif data[0] == 'total_rss':
-                            gauge_memory_rss.add_metric([user, account, job], int(data[1]))
-                        elif data[0] == 'total_rss_huge':
-                            gauge_memory_rss_huge.add_metric([user, account, job], int(data[1]))
-                        elif data[0] == 'total_mapped_file':
-                            gauge_memory_mapped_file.add_metric([user, account, job], int(data[1]))
-                        elif data[0] == 'total_active_file':
-                            gauge_memory_active_file.add_metric([user, account, job], int(data[1]))
-                        elif data[0] == 'total_inactive_file':
-                            gauge_memory_inactive_file.add_metric([user, account, job], int(data[1]))
-                        elif data[0] == 'total_unevictable':
-                            gauge_memory_unevictable.add_metric([user, account, job], int(data[1]))
+            with open(job_dir + ('memory.limit_in_bytes' if cgroups == 1 else 'memory.max'), 'r') as f_limit:
+                gauge_memory_limit.add_metric([user, account, job], int(f_limit.read()))
 
-                # get the allocated cores
-                with open('/sys/fs/cgroup/cpuset/slurm/uid_{}/job_{}/\
-cpuset.effective_cpus'.format(uid, job), 'r') as f_cores:
-                    cores = split_range(f_cores.read())
-                with open('/sys/fs/cgroup/cpu,cpuacct/slurm/uid_{}/job_{}/\
-cpuacct.usage_percpu'.format(uid, job), 'r') as f_usage:
+            with open(job_dir + 'memory.stat', 'r') as f_stats:
+                stats = dict(line.split() for line in f_stats.readlines())
+            if cgroup == 1:
+                gauge_memory_cache.add_metric(
+                    [user, account, job], int(stats['total_cache']))
+                gauge_memory_rss.add_metric(
+                    [user, account, job], int(stats['total_rss']))
+                gauge_memory_rss_huge.add_metric(
+                    [user, account, job], int(stats['total_rss_huge']))
+                gauge_memory_mapped_file.add_metric(
+                    [user, account, job], int(stats['total_mapped_file']))
+                gauge_memory_active_file.add_metric(
+                    [user, account, job], int(stats['total_active_file']))
+                gauge_memory_inactive_file.add_metric(
+                    [user, account, job], int(stats['total_inactive_file']))
+                gauge_memory_unevictable.add_metric(
+                    [user, account, job], int(stats['total_unevictable']))
+            else:
+                gauge_memory_cache.add_metric(
+                    [user, account, job], int(stats['file']))
+                gauge_memory_rss.add_metric(
+                    [user, account, job],
+                    int(stats['anon']) + int(stats['swapcached']))
+                gauge_memory_rss_huge.add_metric(
+                    [user, account, job], int(stats['anon_thp']))
+                gauge_memory_mapped_file.add_metric(
+                    [user, account, job],
+                    int(stats['file_mapped']) + int(stats['shmem']))
+                gauge_memory_active_file.add_metric(
+                    [user, account, job], int(stats['active_file']))
+                gauge_memory_inactive_file.add_metric(
+                    [user, account, job], int(stats['inactive_file']))
+                gauge_memory_unevictable.add_metric(
+                    [user, account, job], int(stats['unevictable']))
+
+            # get the allocated cores
+            if cgroup == 1
+                cpuset_path = '/sys/fs/cgroup/cpuset/slurm/uid_{}/job_{}/cpuset.effective_cpus'.format(uid, job)
+            else:
+                cpuset_path = os.path.join(job_dir, 'cpuset.cpus.effective')
+
+            with open(cpuset_path, 'r') as f_cores:
+                cores = split_range(f_cores.read())
+
+            if cgroup == 1:
+                # There is no equivalent to this in cgroups v2
+                with open('/sys/fs/cgroup/cpu,cpuacct/slurm/uid_{}/job_{}/cpuacct.usage_percpu'.format(uid, job), 'r') as f_usage:
                     cpu_usages = f_usage.read().split()
                     for core in cores:
                         counter_core_usage.add_metric([user, account, job, str(core)],
-                                                      int(cpu_usages[core]))
+                                                    int(cpu_usages[core]))
 
-                processes = 0
-                tasks_state = {}
-                for proc in procs:
-                    try:
-                        p = psutil.Process(proc)
-                        cmdline = p.cmdline()
-                    except psutil.NoSuchProcess:
-                        continue
-                    if len(cmdline) == 0:
-                        # sometimes the cmdline is empty, we don't want to count it
-                        continue
-                    if cmdline[0] == '/bin/bash':
-                        if len(cmdline) > 1:
-                            if '/var/spool' in cmdline[1] and 'slurm_script' in cmdline[1]:
-                                # This is the bash script of the job, we don't want to count it
-                                continue
-                    processes += 1
-
-                    for t in p.threads():
-                        try:
-                            pt = psutil.Process(t.id)
-                        except psutil.NoSuchProcess:
-                            # The thread disappeared between the time we got the list and now
+            processes = 0
+            tasks_state = {}
+            for proc in procs:
+                try:
+                    p = psutil.Process(proc)
+                    cmdline = p.cmdline()
+                except psutil.NoSuchProcess:
+                    continue
+                if len(cmdline) == 0:
+                    # sometimes the cmdline is empty, we don't want to count it
+                    continue
+                if cmdline[0] == '/bin/bash':
+                    if len(cmdline) > 1:
+                        if '/var/spool' in cmdline[1] and 'slurm_script' in cmdline[1]:
+                            # This is the bash script of the job, we don't want to count it
                             continue
-                        pt_status = pt.status()
-                        if pt_status in tasks_state:
-                            tasks_state[pt_status] += 1
-                        else:
-                            tasks_state[pt_status] = 1
+                processes += 1
 
-                for status in tasks_state.keys():
-                    gauge_threads_count.add_metric([user, account, job, status], tasks_state[status])
-                gauge_process_count.add_metric([user, account, job], processes)
-
-                processes_sum = {}
-                for proc in procs:
-                    # get the counter_process_usage data
+                for t in p.threads():
                     try:
-                        p = psutil.Process(proc)
-                        with p.oneshot():
-                            exe = p.exe()
-                        if os.path.basename(exe) in ['ssh', 'sshd', 'bash', 'srun']:
-                            # We don't want to count them
-                            continue
-                        else:
-                            t = p.cpu_times().user + p.cpu_times().system + p.cpu_times().children_user + p.cpu_times().children_system
-                            if exe in processes_sum:
-                                processes_sum[exe] += t
-                            else:
-                                processes_sum[exe] = t
+                        pt = psutil.Process(t.id)
                     except psutil.NoSuchProcess:
+                        # The thread disappeared between the time we got the list and now
                         continue
+                    pt_status = pt.status()
+                    if pt_status in tasks_state:
+                        tasks_state[pt_status] += 1
+                    else:
+                        tasks_state[pt_status] = 1
 
-                # we only count the processes that used more than 60 seconds of CPU
-                processes_sum_filtered = processes_sum.copy()
-                for exe in processes_sum.keys():
-                    if processes_sum[exe] < 60:
-                        del processes_sum_filtered[exe]
+            for status in tasks_state.keys():
+                gauge_threads_count.add_metric([user, account, job, status], tasks_state[status])
+            gauge_process_count.add_metric([user, account, job], processes)
 
-                for exe in processes_sum_filtered.keys():
-                    counter_process_usage.add_metric([user, account, job, exe], processes_sum_filtered[exe])
+            processes_sum = {}
+            for proc in procs:
+                # get the counter_process_usage data
+                try:
+                    p = psutil.Process(proc)
+                    with p.oneshot():
+                        exe = p.exe()
+                    if os.path.basename(exe) in ['ssh', 'sshd', 'bash', 'srun']:
+                        # We don't want to count them
+                        continue
+                    else:
+                        t = p.cpu_times().user + p.cpu_times().system + p.cpu_times().children_user + p.cpu_times().children_system
+                        if exe in processes_sum:
+                            processes_sum[exe] += t
+                        else:
+                            processes_sum[exe] = t
+                except psutil.NoSuchProcess:
+                    continue
+
+            # we only count the processes that used more than 60 seconds of CPU
+            processes_sum_filtered = processes_sum.copy()
+            for exe in processes_sum.keys():
+                if processes_sum[exe] < 60:
+                    del processes_sum_filtered[exe]
+
+            for exe in processes_sum_filtered.keys():
+                counter_process_usage.add_metric([user, account, job, exe], processes_sum_filtered[exe])
 
                 if self.MONITOR_PYNVML:
                     for gpu in gpu_set:

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -399,7 +399,7 @@ per elapsed cycle)',
                     [user, account, job], int(stats['unevictable']))
 
             # get the allocated cores
-            if cgroup == 1
+            if cgroup == 1:
                 cpuset_path = '/sys/fs/cgroup/cpuset/slurm/uid_{}/job_{}/cpuset.effective_cpus'.format(uid, job)
             else:
                 cpuset_path = os.path.join(job_dir, 'cpuset.cpus.effective')

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -64,16 +64,11 @@ def get_env(pid):
     """
     Return the environment variables of a process
     """
-    environments = {}
     try:
-        with open('/proc/{}/environ'.format(pid), 'r', encoding='utf-8') as env_f:
-            for env in env_f.read().split('\000'):
-                r_env = re.match(r'(.*)=(.*)', env)
-                if r_env:
-                    environments[r_env.group(1)] = r_env.group(2)
-    except FileNotFoundError:
-        raise ValueError('Process {} environment does not exist'.format(pid))
-    return environments
+        ps = psutil.Proc(pid)
+        return ps.environ()
+    except psutil.NoSuchProcess:
+        raise ValueError("Could not get environment for {}".format(pid))
 
 
 def cgroup_gpus(uid, job):

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -30,7 +30,7 @@ def cgroup_processes(job_dir):
     procs = []
     res_uid = -1
     for (path, _, _)  in os.walk(job_dir):
-        with open(os.path.join(path, cgroup.procs), 'r') as procs:
+        with open(os.path.join(path, "cgroup.procs"), 'r') as procs:
             for proc in procs.readlines():
                 pid = int(proc)
                 try:

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -29,7 +29,7 @@ def cgroup_processes(job_dir):
     """
     procs = []
     res_uid = -1
-    for (path, _, _)  in os.walk(job_dir):
+    for (path, _, _) in os.walk(job_dir):
         with open(os.path.join(path, "cgroup.procs"), 'r') as fprocs:
             for proc in fprocs.readlines():
                 pid = int(proc)
@@ -413,7 +413,7 @@ per elapsed cycle)',
                     cpu_usages = f_usage.read().split()
                     for core in cores:
                         counter_core_usage.add_metric([user, account, job, str(core)],
-                                                    int(cpu_usages[core]))
+                                                      int(cpu_usages[core]))
 
             processes = 0
             tasks_state = {}

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -34,7 +34,7 @@ def cgroup_processes(job_dir):
             for proc in procs.readlines():
                 pid = int(proc)
                 try:
-                    ps = psutil.Proc(pid)
+                    ps = psutil.Process(pid)
                     uid = ps.uids().real
                     if uid != 0:
                         res_uid = uid
@@ -65,7 +65,7 @@ def get_env(pid):
     Return the environment variables of a process
     """
     try:
-        ps = psutil.Proc(pid)
+        ps = psutil.Process(pid)
         return ps.environ()
     except psutil.NoSuchProcess:
         raise ValueError("Could not get environment for {}".format(pid))


### PR DESCRIPTION
We have to drop some stats

- `memory.max_usage_in_bytes` becomes `memory.peak`, but this is not in any currently released kernel (https://github.com/torvalds/linux/commit/8e20d4b332660a32e842e20c34cfc3b3456bc6dc, looks like it will be part of 6.8) 
- `cpuacct.usage_percpu` is exposed via eBPF in kernel 6.6+, but not though cgroupfs although it might be for a future kernel.  I'm not sure I want to write BPF tooling just for that.  Not to mention that our cluster is on kernel 5.15 anyway, so it wouldn't work.