### PR TITLE
Make sure this is started after DCGM if it is configured on the machine

### DIFF
--- a/slurm-job-exporter.service
+++ b/slurm-job-exporter.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Slurm-job-exporter
 After=network.target
+After=nvidia-dcgm.service
+Wants=nvidia-dcgm.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
The systemd `Wants=` dependency means that DCGM is not required to start the service, but if it is present it will be started as well.

`After=` just makes sure that DCGM is up and running before we start, if it is to be started.
