### PR TITLE
L4 does not support FP64

### DIFF
--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -161,7 +161,7 @@ class SlurmJobCollector(object):
                         device = pydcgm.dcgm_agent.dcgmGetDeviceAttributes(self.handle.handle, gpu_id)
                         name = device.identifiers.deviceName
                         print('Detected gpu {} with ID {}'.format(name, gpu_id))
-                        if name in ['NVIDIA RTX A6000']:
+                        if name in ['NVIDIA RTX A6000', 'NVIDIA L4']:
                             # This GPU does not supports fp64, we don't support a mix of fp64 and non-fp64 GPUs in the same node
                             print('Removing fp64 metrics since {} does not support fp64'.format(name))
                             del self.fieldIds_dict[dcgm_fields.DCGM_FI_PROF_PIPE_FP64_ACTIVE]


### PR DESCRIPTION
From issue https://github.com/guilbaults/slurm-job-exporter/issues/24