### PR TITLE
Fix for DCGM version 4 path changes

### DIFF
--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -123,7 +123,11 @@ class SlurmJobCollector(object):
             if monitor == 'dcgm' and proc.name() == 'nv-hostengine':
                 # DCGM is running on this host
                 # Find the installed version
-                dcgm_version=os.popen("""nv-hostengine --version | awk '/^Version/ { printf "%s",substr($3,1,1) }'""").read()
+                #dcgm_version=os.popen("""nv-hostengine --version | awk '/^Version/ { printf "%s",substr($3,1,1) }'""").read()
+                nvh_out=os.popen("""nv-hostengine --version""").read().split("\n")
+                rexp=re.compile("^Version.*")
+                dcgm_version=list(filter(rexp.match, nvh_out))[0].split(" : ")[1].split(".")[0]
+
                 # Set DCGM bindings
                 if int(dcgm_version) >= 4:
                     dcgm_binding_path = "/usr/share/datacenter-gpu-manager-" + dcgm_version +  "/bindings/python3/"

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -122,8 +122,14 @@ class SlurmJobCollector(object):
         for proc in psutil.process_iter():
             if monitor == 'dcgm' and proc.name() == 'nv-hostengine':
                 # DCGM is running on this host
-                # Load DCGM bindings from the RPM
-                sys.path.insert(0, '/usr/local/dcgm/bindings/python3/')
+                # Find the installed version
+                dcgm_version=os.popen("""nv-hostengine --version | awk '/^Version/ { printf "%s",substr($3,1,1) }'""").read()
+                # Set DCGM bindings
+                if int(dcgm_version) >= 4:
+                    dcgm_binding_path = "/usr/share/datacenter-gpu-manager-" + dcgm_version +  "/bindings/python3/"
+                else:
+                    dcgm_binding_path = "/usr/local/dcgm/bindings/python3/"
+                sys.path.insert(0, dcgm_binding_path)
 
                 try:
                     import pydcgm

--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -123,8 +123,8 @@ class SlurmJobCollector(object):
             if monitor == 'dcgm' and proc.name() == 'nv-hostengine':
                 # DCGM is running on this host
                 # Find the installed version
-                #dcgm_version=os.popen("""nv-hostengine --version | awk '/^Version/ { printf "%s",substr($3,1,1) }'""").read()
                 nvh_out=os.popen("""nv-hostengine --version""").read().split("\n")
+                # Search DCGM major version from the line similar to : "Version : 4.4.0"
                 rexp=re.compile("^Version.*")
                 dcgm_version=list(filter(rexp.match, nvh_out))[0].split(" : ")[1].split(".")[0]
 


### PR DESCRIPTION
Since version 4, DCGM changed its install path and added its major version number in its directory name. Like :

`/usr/share/datacenter-gpu-manager-4`

Paths are the same for deb ans rpm builds according to those files :

- https://github.com/NVIDIA/DCGM/blob/master/scripts/verify_package_contents/datacenter-gpu-manager-config_all.deb.txt
- https://github.com/NVIDIA/DCGM/blob/master/scripts/verify_package_contents/datacenter-gpu-manager-config_noarch.rpm.txt

This pull request finds the DCGM major release, and fix the python3 binding path accordingly.