### PR TITLE
Query DCGM to get the available stats for the GPU model in the machine

### DIFF
--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -316,6 +316,7 @@ global (device) memory was being read or written.',
                 labels=['user', 'account', 'slurmjobid', 'gpu', 'gpu_type'])
 
         if self.MONITOR_DCGM:
+            import dcgm_fields  # to statisfy flake8
             # DCGM have additional metrics for GPU
             if dcgm_fields.DCGM_FI_PROF_SM_OCCUPANCY in self.used_metrics:
                 gauge_sm_occupancy_gpu = GaugeMetricFamily(
@@ -346,12 +347,12 @@ per elapsed cycle)',
                     'Ratio of cycles the fp16 pipe is active',
                     labels=['user', 'account', 'slurmjobid', 'gpu', 'gpu_type'])
             if (dcgm_fields.DCGM_FI_PROF_NVLINK_TX_BYTES in self.used_metrics or
-                dcgm_fields.DCGM_FI_PROF_NVLINK_RX_BYTES in self.used_metrics):
+                    dcgm_fields.DCGM_FI_PROF_NVLINK_RX_BYTES in self.used_metrics):
                 gauge_nvlink_gpu = GaugeMetricFamily(
                     'slurm_job_nvlink_gpu', 'Nvlink tx/rx bytes per second',
                     labels=['user', 'account', 'slurmjobid', 'gpu', 'gpu_type', 'direction'])
             if (dcgm_fields.DCGM_FI_PROF_PCIE_TX_BYTES in self.used_metrics or
-                dcgm_fields.DCGM_FI_PROF_PCIE_RX_BYTES in self.used_metrics):
+                    dcgm_fields.DCGM_FI_PROF_PCIE_RX_BYTES in self.used_metrics):
                 gauge_pcie_gpu = GaugeMetricFamily(
                     'slurm_job_pcie_gpu', 'PCIe tx/rx bytes per second',
                     labels=['user', 'account', 'slurmjobid', 'gpu', 'gpu_type', 'direction'])
@@ -659,10 +660,10 @@ per elapsed cycle)',
             if dcgm_fields.DCGM_FI_PROF_PIPE_FP16_ACTIVE in self.used_metrics:
                 yield gauge_fp16_gpu
             if (dcgm_fields.DCGM_FI_PROF_PCIE_TX_BYTES in self.used_metrics or
-                dcgm_fields.DCGM_FI_PROF_PCIE_RX_BYTES in self.used_metrics):
+                    dcgm_fields.DCGM_FI_PROF_PCIE_RX_BYTES in self.used_metrics):
                 yield gauge_pcie_gpu
             if (dcgm_fields.DCGM_FI_PROF_NVLINK_TX_BYTES in self.used_metrics or
-                dcgm_fields.DCGM_FI_PROF_NVLINK_RX_BYTES in self.used_metrics):
+                    dcgm_fields.DCGM_FI_PROF_NVLINK_RX_BYTES in self.used_metrics):
                 yield gauge_nvlink_gpu
 
 


### PR DESCRIPTION
There was a workaround to retry collecting stats without fp64 because some GPU don't have that available.  We have another model that doesn't have nvlink stats.

Instead of adding another manual fallback, I just used dcgmProfGetSupportedMetricGroups to get the list of available metrics for the GPU model and query the intersection of what we want and what is available.

I've added a printout of the stats that we decide collect so that it can help figure out where the problem comes from if no stats are collected.

The only downside with how I've done things, is that it assumes that all the GPUs in one machine are of the same model. If we want to support heterogenous models in a single machine a lot of things would have to be reworked and we don't need that for our use case, but I am prepared to do it if required.