### PR TITLE
Collect DCGM data for all entities, not just either GPU or MIG.

### DIFF
--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -144,12 +144,7 @@ class SlurmJobCollector(object):
                     import dcgm_structs
 
                     self.handle = pydcgm.DcgmHandle(None, 'localhost')
-                    self.group = pydcgm.DcgmGroup(self.handle, groupName="slurm-job-exporter", groupType=dcgm_structs.DCGM_GROUP_DEFAULT_INSTANCES)
-
-                    if len(self.group.GetEntities()) == 0:
-                        # No MIG, switch to default group
-                        self.group.Delete()
-                        self.group = pydcgm.DcgmGroup(self.handle, groupName="slurm-job-exporter", groupType=dcgm_structs.DCGM_GROUP_DEFAULT)
+                    self.group = pydcgm.DcgmGroup(self.handle, groupName="slurm-job-exporter", groupType=dcgm_structs.DCGM_GROUP_DEFAULT_ENTITIES)
 
                     # https://github.com/NVIDIA/gpu-monitoring-tools/blob/master/bindings/go/dcgm/dcgm_fields.h
                     self.fieldIds_dict = {


### PR DESCRIPTION
If there are GPUs with MIG enabled plus others without on a node using DCGM monitoring, slurm-job-exporter would only recognise MIG devices. If a job ran with a non-MIG GPU, all metric collection would fail, not just for that job.

This commit alters the set of DCGM tracked devices to all types, not choosing between GPUs or MIG devices. This will also include any nvswitches. As I do not have any nvswitches, unfortunately I cannot test if that is a problem.