### PR TITLE
Update PIDFile path in slurm-job-exporter.service

### DIFF
--- a/slurm-job-exporter.service
+++ b/slurm-job-exporter.service
@@ -8,7 +8,7 @@ Wants=nvidia-dcgm.service
 Type=simple
 EnvironmentFile=-/etc/sysconfig/slurm-job-exporter.conf
 ExecStart=/usr/bin/slurm-job-exporter
-PIDFile=/var/run/slurm-job-exporter.pid
+PIDFile=/run/slurm-job-exporter.pid
 KillMode=process
 
 [Install]


### PR DESCRIPTION
To avoid: 
```
Apr 13 20:31:20 cpupool1.int.ecole.calculquebec.cloud systemd[1]: /usr/lib/systemd/system/slurm-job-exporter.service:11: PIDFile= references a path below legacy directory /var/run/, updating /var/run/slurm-job-exporter.pid → /run/slurm-job-exporter.pid; please update the unit file accordingly.
```