### PR TITLE
Handle case where proc no longer exists before checking its name

### DIFF
--- a/slurm-job-exporter.py
+++ b/slurm-job-exporter.py
@@ -123,7 +123,11 @@ class SlurmJobCollector(object):
         self.MONITOR_PYNVML = False
         self.UNSUPPORTED_FEATURES = []
         for proc in psutil.process_iter():
-            if monitor == 'dcgm' and proc.name() == 'nv-hostengine':
+            try:
+                proc_name = proc.name()
+            except psutil.NoSuchProcess:
+                continue
+            if monitor == 'dcgm' and proc_name == 'nv-hostengine':
                 # DCGM is running on this host
                 # Find the installed version
                 nvh_out = os.popen("""nv-hostengine --version""").read().split("\n")


### PR DESCRIPTION
I experienced the following traceback after launching slurm-job-exporter because one of the processes identified by psutil.process_iter no longer existed once we tried looking up its name. This PR fixes this by retrieving the name in a try/except and skip the process if an exception is retrieved when trying to get the process' name.
```
slurm-job-exporter[64350]: Traceback (most recent call last):
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/_common.py", line 447, in wrapper
slurm-job-exporter[64350]:     ret = self._cache[fun]
slurm-job-exporter[64350]: AttributeError: _cache
slurm-job-exporter[64350]: During handling of the above exception, another exception occurred:
slurm-job-exporter[64350]: Traceback (most recent call last):
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/_pslinux.py", line 1576, in wrapper
slurm-job-exporter[64350]:     return fun(self, *args, **kwargs)
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/_common.py", line 450, in wrapper
slurm-job-exporter[64350]:     return fun(self)
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/_pslinux.py", line 1618, in _parse_stat_file
slurm-job-exporter[64350]:     with open_binary("%s/%s/stat" % (self._procfs_path, self.pid)) as f:
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/_common.py", line 711, in open_binary
slurm-job-exporter[64350]:     return open(fname, "rb", **kwargs)
slurm-job-exporter[64350]: FileNotFoundError: [Errno 2] No such file or directory: '/proc/64371/stat'
slurm-job-exporter[64350]: During handling of the above exception, another exception occurred:
slurm-job-exporter[64350]: Traceback (most recent call last):
slurm-job-exporter[64350]:   File "/usr/bin/slurm-job-exporter", line 667, in <module>
slurm-job-exporter[64350]:     APP = make_wsgi_app(SlurmJobCollector(dcgm_update_interval=ARGS.dcgm_update_interval, monitor=ARGS.monitor>
slurm-job-exporter[64350]:   File "/usr/bin/slurm-job-exporter", line 124, in __init__
slurm-job-exporter[64350]:     if monitor == 'dcgm' and proc.name() == 'nv-hostengine':
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/__init__.py", line 617, in name
slurm-job-exporter[64350]:     name = self._proc.name()
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/_pslinux.py", line 1576, in wrapper
slurm-job-exporter[64350]:     return fun(self, *args, **kwargs)
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/_pslinux.py", line 1671, in name
slurm-job-exporter[64350]:     name = self._parse_stat_file()['name']
slurm-job-exporter[64350]:   File "/usr/lib64/python3.9/site-packages/psutil/_pslinux.py", line 1583, in wrapper
slurm-job-exporter[64350]:     raise NoSuchProcess(self.pid, self._name)
slurm-job-exporter[64350]: psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=64371)
```